### PR TITLE
feat: handle stalemates

### DIFF
--- a/Chess/BabsonTask.lean
+++ b/Chess/BabsonTask.lean
@@ -1,0 +1,262 @@
+import Chess.Basic
+import Chess.Tactics
+import Chess.Widgets
+import Chess.NextMoveTactic
+
+theorem extracted_4 :
+  valid_moves
+          ╔════════════════╗
+          ║♗]░░▓▓♛]▓▓░░▓▓░░║
+          ║♙]▓▓░░♙]♟]♘]♔]▓▓║
+          ║▓▓░░▓▓░░♙]♟]▓▓░░║
+          ║♙]▓▓♟]▓▓░░♙]░░▓▓║
+          ║▓▓░░♙]♚}▓▓♝]▓▓♖]║
+          ║░░♟]░░▓▓░░▓▓░░▓▓║
+          ║♟]♘]▓▓♙]▓▓♙]▓▓░░║
+          ║♕]♖]░░▓▓░░▓▓░░▓▓║
+          ╚════════════════╝ ≠
+    ∅ := by
+    exact ne_of_beq_false rfl
+
+def example_5 :=
+    ╔════════════════╗
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║░░▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║░░▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║♔}♕]░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║♚]▓▓░░▓▓░░▓▓░░▓▓║
+    ╚════════════════╝
+
+def babsonTask :=
+      ╔════════════════╗
+      ║♗]♛]░░♗]░░♔}░░▓▓║
+      ║▓▓░░▓▓♙]♟]♘]▓▓░░║
+      ║♙]▓▓░░▓▓♙]♟]░░▓▓║
+      ║♙]░░♟]░░▓▓♙]▓▓░░║
+      ║░░▓▓♙]♚]░░♝]░░♖]║
+      ║▓▓♟]▓▓░░▓▓░░▓▓░░║
+      ║♟]♘]░░♙]░░♙]░░▓▓║
+      ║♕]♖]▓▓░░▓▓░░▓▓░░║
+      ╚════════════════╝
+
+set_option linter.hashCommand false
+#widget ChessPositionWidget with { position? := example_5 : ChessPositionWidgetProps }
+
+theorem forcedWinDemo :
+    ForcedWin .white
+      example_5 := by
+  with_panel_widgets [ForcedWinWidget]
+    move "Qb2"
+    checkmate
+
+theorem extracted_1 :
+  ForcedWin
+    (match
+      match
+        match
+          match babsonTask.turn with
+          | Side.white => Side.black
+          | Side.black => Side.white with
+        | Side.white => Side.black
+        | Side.black => Side.white with
+      | Side.white => Side.black
+      | Side.black => Side.white with
+    | Side.white => Side.black
+    | Side.black => Side.white)
+        ╔════════════════╗
+        ║♗]░░▓▓░░▓▓░░♛]░░║
+        ║♙]▓▓░░♙]♟]♘]♔}▓▓║
+        ║▓▓░░▓▓░░♙]♟]▓▓░░║
+        ║♙]▓▓♟]▓▓░░♙]░░▓▓║
+        ║▓▓░░♙]♚]▓▓♝]▓▓♖]║
+        ║░░♟]░░▓▓░░▓▓░░▓▓║
+        ║♟]♘]▓▓♙]▓▓♙]▓▓░░║
+        ║♕]♖]░░▓▓░░▓▓░░▓▓║
+        ╚════════════════╝ := by
+        move "K×g8"
+        opponent_move
+        · simp;move "Pd8=Q";checkmate
+        · simp;move "Pd8=Q";checkmate
+        · simp;move "Pd8=Q";checkmate
+        · simp;move "Pd8=Q";checkmate
+        · decide
+
+theorem extracted_2 :
+  ForcedWin
+    (match
+      match
+        match
+          match babsonTask.turn with
+          | Side.white => Side.black
+          | Side.black => Side.white with
+        | Side.white => Side.black
+        | Side.black => Side.white with
+      | Side.white => Side.black
+      | Side.black => Side.white with
+    | Side.white => Side.black
+    | Side.black => Side.white)
+        ╔════════════════╗
+        ║♗]░░▓▓░░▓▓░░▓▓♛]║
+        ║♙]▓▓░░♙]♟]♘]♔}▓▓║
+        ║▓▓░░▓▓░░♙]♟]▓▓░░║
+        ║♙]▓▓♟]▓▓░░♙]░░▓▓║
+        ║▓▓░░♙]♚]▓▓♝]▓▓♖]║
+        ║░░♟]░░▓▓░░▓▓░░▓▓║
+        ║♟]♘]▓▓♙]▓▓♙]▓▓░░║
+        ║♕]♖]░░▓▓░░▓▓░░▓▓║
+        ╚════════════════╝ := by
+        move "K×h8"
+        opponent_move
+        · simp;move "Pd8=Q";checkmate
+        · simp;move "Pd8=Q";checkmate
+        · simp;move "Pd8=Q";checkmate
+        · simp;move "Pd8=Q";checkmate
+        · exact ne_of_beq_false rfl
+
+theorem extracted_3 :
+  ForcedWin
+    (match
+      match
+        match
+          match babsonTask.turn with
+          | Side.white => Side.black
+          | Side.black => Side.white with
+        | Side.white => Side.black
+        | Side.black => Side.white with
+      | Side.white => Side.black
+      | Side.black => Side.white with
+    | Side.white => Side.black
+    | Side.black => Side.white)
+        ╔════════════════╗
+        ║♗]░░▓▓░░▓▓♛]▓▓░░║
+        ║♙]▓▓░░♙]♟]♘]♔}▓▓║
+        ║▓▓░░▓▓░░♙]♟]▓▓░░║
+        ║♙]▓▓♟]▓▓░░♙]░░▓▓║
+        ║▓▓░░♙]♚]▓▓♝]▓▓♖]║
+        ║░░♟]░░▓▓░░▓▓░░▓▓║
+        ║♟]♘]▓▓♙]▓▓♙]▓▓░░║
+        ║♕]♖]░░▓▓░░▓▓░░▓▓║
+        ╚════════════════╝ := by
+      with_panel_widgets [ForcedWinWidget]
+        move "K×f8"
+        opponent_move
+        all_goals
+            try (simp;move "Pd8=Q";checkmate)
+        · exact ne_of_beq_false rfl
+
+
+set_option maxHeartbeats 0
+theorem extracted_4' :
+  ForcedWin
+    (match
+      match babsonTask.turn with
+      | Side.white => Side.black
+      | Side.black => Side.white with
+    | Side.white => Side.black
+    | Side.black => Side.white)
+        ╔════════════════╗
+        ║♗]░░▓▓♛]▓▓♔}▓▓░░║
+        ║♙]▓▓░░♙]♟]♘]░░▓▓║
+        ║▓▓░░▓▓░░♙]♟]▓▓░░║
+        ║♙]▓▓♟]▓▓░░♙]░░▓▓║
+        ║▓▓░░♙]♚]▓▓♝]▓▓♖]║
+        ║░░♟]░░▓▓░░▓▓░░▓▓║
+        ║♟]♘]▓▓♙]▓▓♙]▓▓░░║
+        ║♕]♖]░░▓▓░░▓▓░░▓▓║
+        ╚════════════════╝ := by
+    with_panel_widgets [ForcedWinWidget]
+      move "Kg7"
+      simp
+      opponent_move
+      · simp
+        move "d8=Q"
+        opponent_move
+        all_goals try (move "R×f4";checkmate)
+        exact ne_of_beq_false rfl
+        -- goal 1
+      · simp;move "R×f4"
+        checkmate
+        -- goal 2
+      · simp;move "R×f4"
+        checkmate
+        -- goal 3
+      · simp;move "R×f4"
+        checkmate
+        -- goal 4
+      · simp;exact extracted_3 -- goal 5
+      · simp;exact extracted_1 -- goal 6
+      · simp;exact extracted_2 -- goal 7
+      · simp;move "R×f4";checkmate -- goal 8
+      · simp;move "R×f4";checkmate -- goal 9
+      · simp
+        move "d8=Q"
+        opponent_move
+        all_goals try (move "R×f4";checkmate)
+        exact ne_of_beq_false rfl -- goal 10
+      · simp
+        move "d8=Q"
+        opponent_move
+        all_goals try (move "R×f4";checkmate)
+        simp
+        move "Qd3"
+        checkmate
+        exact ne_of_beq_false rfl -- goal 11
+      · simp;move "R×f4";opponent_move
+        move "R×e4";checkmate
+        exact ne_of_beq_false rfl -- goal 12
+      · simp;move "R×f4";checkmate -- goal 13
+      · simp;move "R×f4";opponent_move
+        move "R×e4";checkmate
+        exact ne_of_beq_false rfl -- goal 14
+      · simp;move "R×f4";checkmate -- goal 15
+      sorry
+
+
+
+
+
+
+
+
+    --   · have := extracted_4 --exact ne_of_beq_false rfl
+        -- convert this
+    --   · sorry
+
+-- set_option maxHeartbeats 0
+-- theorem babsonNotStalemate :
+--     ForcedWin .white
+--       babsonTask := by
+--   with_panel_widgets [ForcedWinWidget]
+--     move "a7"
+--     opponent_move
+--     · move "R×f4"
+--       checkmate
+--     · simp;move "B×c7"
+--       opponent_move
+
+--       · simp;sorry
+--       sorry
+--       sorry
+--       sorry
+--       sorry
+--     · simp;sorry
+--     · simp;sorry
+--     · move "R×f4"
+--       checkmate
+--     · exact extracted_4
+--     · simp;sorry
+--     · move "R×f4"
+--       checkmate
+--     · move "R×f4"
+--       checkmate
+--     · move "R×f4"
+--       checkmate
+--     · simp;sorry
+--     · simp;sorry
+--     · simp;sorry
+--     · simp;sorry
+--     · simp;sorry
+--     · exact ne_of_beq_false rfl

--- a/Chess/BabsonTaskNotLose.lean
+++ b/Chess/BabsonTaskNotLose.lean
@@ -1,0 +1,223 @@
+import Chess.Basic
+import Chess.Tactics
+import Chess.Widgets
+import Chess.NextMoveTactic
+
+
+lemma practice :
+  ForcedWin .white (by
+    apply Position.mk
+    · unfold Squares
+      exact [
+        [some (Piece.rook, .white),none,none,none,none,none,none,none],
+        [some (Piece.rook, .white),none,none,none,none,none,none,none],
+        [some (Piece.rook, .white),none,none,none,none,none,none,none],
+        [some (Piece.rook, .white),none,none,none,none,none,none,none],
+        [some (Piece.rook, .white),none,none,none,none,none,none,none],
+        [some (Piece.rook, .white),none,none,none,none,none,none,none],
+        [some (Piece.rook, .white),none,none,none,none,none,none,none],
+        [some (Piece.rook, .white),none,none,none,none,none,none,none]]
+    · exact .white
+    · apply some
+      exact {row :=0, col := 0}) := by
+  with_panel_widgets [ForcedWinWidget]
+      sorry
+
+def example_5 :=
+    ╔════════════════╗
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║░░▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║░░▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║♔}♕]░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║♚]▓▓░░▓▓░░▓▓░░▓▓║
+    ╚════════════════╝
+
+def babsonTask :=
+      ╔════════════════╗
+      ║♗]♛]░░♗]░░♔}░░▓▓║
+      ║▓▓░░▓▓♙]♟]♘]▓▓░░║
+      ║♙]▓▓░░▓▓♙]♟]░░▓▓║
+      ║♙]░░♟]░░▓▓♙]▓▓░░║
+      ║░░▓▓♙]♚]░░♝]░░♖]║
+      ║▓▓♟]▓▓░░▓▓░░▓▓░░║
+      ║♟]♘]░░♙]░░♙]░░▓▓║
+      ║♕]♖]▓▓░░▓▓░░▓▓░░║
+      ╚════════════════╝
+
+set_option linter.hashCommand false
+#widget ChessPositionWidget with { position? := example_5 : ChessPositionWidgetProps }
+
+theorem forcedNotLoseDemo :
+    ForcedNotLose .white
+      example_5 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    moveNotLose "Qb2"
+    checkmateNotLose
+
+theorem extracted_1 :
+  ForcedNotLose
+    (match
+      match
+        match
+          match babsonTask.turn with
+          | Side.white => Side.black
+          | Side.black => Side.white with
+        | Side.white => Side.black
+        | Side.black => Side.white with
+      | Side.white => Side.black
+      | Side.black => Side.white with
+    | Side.white => Side.black
+    | Side.black => Side.white)
+        ╔════════════════╗
+        ║♗]░░▓▓░░▓▓░░♛]░░║
+        ║♙]▓▓░░♙]♟]♘]♔}▓▓║
+        ║▓▓░░▓▓░░♙]♟]▓▓░░║
+        ║♙]▓▓♟]▓▓░░♙]░░▓▓║
+        ║▓▓░░♙]♚]▓▓♝]▓▓♖]║
+        ║░░♟]░░▓▓░░▓▓░░▓▓║
+        ║♟]♘]▓▓♙]▓▓♙]▓▓░░║
+        ║♕]♖]░░▓▓░░▓▓░░▓▓║
+        ╚════════════════╝ := by
+        moveNotLose "K×g8"
+        opponent_moveNotLose
+        all_goals
+          simp;moveNotLose "Pd8=Q";checkmateNotLose
+
+
+theorem extracted_2 :
+  ForcedNotLose
+    (match
+      match
+        match
+          match babsonTask.turn with
+          | Side.white => Side.black
+          | Side.black => Side.white with
+        | Side.white => Side.black
+        | Side.black => Side.white with
+      | Side.white => Side.black
+      | Side.black => Side.white with
+    | Side.white => Side.black
+    | Side.black => Side.white)
+        ╔════════════════╗
+        ║♗]░░▓▓░░▓▓░░▓▓♛]║
+        ║♙]▓▓░░♙]♟]♘]♔}▓▓║
+        ║▓▓░░▓▓░░♙]♟]▓▓░░║
+        ║♙]▓▓♟]▓▓░░♙]░░▓▓║
+        ║▓▓░░♙]♚]▓▓♝]▓▓♖]║
+        ║░░♟]░░▓▓░░▓▓░░▓▓║
+        ║♟]♘]▓▓♙]▓▓♙]▓▓░░║
+        ║♕]♖]░░▓▓░░▓▓░░▓▓║
+        ╚════════════════╝ := by
+        moveNotLose "K×h8"
+        opponent_moveNotLose
+        all_goals
+          simp;moveNotLose "Pd8=Q";checkmateNotLose
+
+
+theorem extracted_3 :
+  ForcedNotLose
+    (match
+      match
+        match
+          match babsonTask.turn with
+          | Side.white => Side.black
+          | Side.black => Side.white with
+        | Side.white => Side.black
+        | Side.black => Side.white with
+      | Side.white => Side.black
+      | Side.black => Side.white with
+    | Side.white => Side.black
+    | Side.black => Side.white)
+        ╔════════════════╗
+        ║♗]░░▓▓░░▓▓♛]▓▓░░║
+        ║♙]▓▓░░♙]♟]♘]♔}▓▓║
+        ║▓▓░░▓▓░░♙]♟]▓▓░░║
+        ║♙]▓▓♟]▓▓░░♙]░░▓▓║
+        ║▓▓░░♙]♚]▓▓♝]▓▓♖]║
+        ║░░♟]░░▓▓░░▓▓░░▓▓║
+        ║♟]♘]▓▓♙]▓▓♙]▓▓░░║
+        ║♕]♖]░░▓▓░░▓▓░░▓▓║
+        ╚════════════════╝ := by
+      with_panel_widgets [ForcedNotLoseWidget]
+        moveNotLose "K×f8"
+        opponent_moveNotLose
+        all_goals
+            try (simp;moveNotLose "Pd8=Q";checkmateNotLose)
+
+
+
+
+set_option maxHeartbeats 0
+theorem extracted_4' :
+  ForcedNotLose
+    (match
+      match babsonTask.turn with
+      | Side.white => Side.black
+      | Side.black => Side.white with
+    | Side.white => Side.black
+    | Side.black => Side.white)
+        ╔════════════════╗
+        ║♗]░░▓▓♛]▓▓♔}▓▓░░║
+        ║♙]▓▓░░♙]♟]♘]░░▓▓║
+        ║▓▓░░▓▓░░♙]♟]▓▓░░║
+        ║♙]▓▓♟]▓▓░░♙]░░▓▓║
+        ║▓▓░░♙]♚]▓▓♝]▓▓♖]║
+        ║░░♟]░░▓▓░░▓▓░░▓▓║
+        ║♟]♘]▓▓♙]▓▓♙]▓▓░░║
+        ║♕]♖]░░▓▓░░▓▓░░▓▓║
+        ╚════════════════╝ := by
+    with_panel_widgets [ForcedNotLoseWidget]
+      moveNotLose "Kg7"
+      simp
+      opponent_moveNotLose
+      all_goals try (moveNotLose "R×f4";checkmateNotLose)
+      all_goals try simp
+      all_goals try
+        moveNotLose "d8=Q"
+        opponent_moveNotLose
+        all_goals try (moveNotLose "R×f4";checkmateNotLose)
+      · exact extracted_3
+      · exact extracted_1
+      · exact extracted_2
+      simp;sorry
+      sorry
+      sorry
+
+      -- · simp
+      --   moveNotLose "d8=Q"
+      --   opponent_moveNotLose
+      --   all_goals try (moveNotLose "R×f4";checkmateNotLose)
+      -- · simp;moveNotLose "R×f4"
+      --   checkmateNotLose
+      -- · simp;moveNotLose "R×f4"
+      --   checkmateNotLose
+      -- · simp;moveNotLose "R×f4"
+      --   checkmateNotLose
+
+      -- · simp;exact extracted_3
+      -- · simp;exact extracted_1
+      -- · simp;exact extracted_2
+      -- · simp;moveNotLose "R×f4";checkmateNotLose
+      -- · simp;moveNotLose "R×f4";checkmateNotLose
+      -- · simp
+      --   moveNotLose "d8=Q"
+      --   -- moveNotLose "b8=Q" -- failed to make moveNotLose
+      --   -- moveNotLose "P×b8=Q" -- failed to make moveNotLose
+      --   opponent_moveNotLose
+      --   all_goals try (moveNotLose "R×f4";checkmateNotLose)
+      -- · simp
+      --   moveNotLose "d8=Q"
+      --   opponent_moveNotLose
+      --   all_goals try (moveNotLose "R×f4";checkmateNotLose)
+      --   simp
+      --   moveNotLose "Qd3"
+      --   checkmateNotLose
+      -- · simp;moveNotLose "R×f4";opponent_moveNotLose
+      --   moveNotLose "R×e4";checkmateNotLose
+      -- · simp;moveNotLose "R×f4";checkmateNotLose
+      -- · simp;moveNotLose "R×f4";opponent_moveNotLose
+      --   moveNotLose "R×e4";checkmateNotLose
+      -- · simp;moveNotLose "R×f4";checkmateNotLose

--- a/Chess/Basic.lean
+++ b/Chess/Basic.lean
@@ -873,6 +873,14 @@ def IsCheckmate (pos : Position) : Prop :=
   then valid_moves pos = []
   else False
 
+/-- This considers a stalemate to be a win for the side
+  who doesn't have the move. -/
+inductive ForcedNotLose : Side → Position → Prop where
+| Checkmate (p : Position) : IsCheckmate p → ForcedNotLose p.turn.other p
+| Self (p : Position) (m : ChessMove) (p1 : Position) :
+   (m, p1) ∈ valid_moves p → ForcedNotLose p.turn p1 → ForcedNotLose p.turn p
+| Opponent (p : Position) :
+   (∀ vm ∈ valid_moves p, ForcedNotLose p.turn.other vm.snd) → ForcedNotLose p.turn.other p
 /--
  `ForcedWin side pos` means than `side` has a forced win
  at position `pos`.
@@ -882,9 +890,9 @@ inductive ForcedWin : Side → Position → Prop where
 | Self (p : Position) (m : ChessMove) (p1 : Position) :
    (m, p1) ∈ valid_moves p → ForcedWin p.turn p1 → ForcedWin p.turn p
 | Opponent (p : Position) :
-   (∀ vm ∈ valid_moves p, ForcedWin p.turn.other vm.snd) → ForcedWin p.turn.other p
-   -- FIXME: This is wrong because it considers a stalemate to be a win for the side
-   --        who doesn't have the move.
+   (∀ vm ∈ valid_moves p, ForcedWin p.turn.other vm.snd) → valid_moves p ≠ ∅ → ForcedWin p.turn.other p
+
+
 --------------
 
 def make_move (pos : Position) (cm : ChessMove) : Option Position :=

--- a/Chess/Basic.lean
+++ b/Chess/Basic.lean
@@ -881,6 +881,18 @@ inductive ForcedNotLose : Side → Position → Prop where
    (m, p1) ∈ valid_moves p → ForcedNotLose p.turn p1 → ForcedNotLose p.turn p
 | Opponent (p : Position) :
    (∀ vm ∈ valid_moves p, ForcedNotLose p.turn.other vm.snd) → ForcedNotLose p.turn.other p
+
+inductive ForcedNotLose' (s : Side) (p : Position) : Prop where
+| Checkmate (h : s = p.turn.other) :
+    IsCheckmate p → ForcedNotLose' s p
+| Opponent (h : s = p.turn.other) :
+  (∀ vm ∈ valid_moves p, ForcedNotLose p.turn.other vm.snd) →
+  ForcedNotLose' s p
+| Self (h : s = p.turn)
+  (m : ChessMove) (p1 : Position) :
+  (m, p1) ∈ valid_moves p → ForcedNotLose s p1 →
+  ForcedNotLose' s p
+
 /--
  `ForcedWin side pos` means than `side` has a forced win
  at position `pos`.
@@ -892,6 +904,25 @@ inductive ForcedWin : Side → Position → Prop where
 | Opponent (p : Position) :
    (∀ vm ∈ valid_moves p, ForcedWin p.turn.other vm.snd) → valid_moves p ≠ ∅ → ForcedWin p.turn.other p
 
+inductive ForcedWinIn : Nat → Side → Position → Prop where
+| Checkmate (p : Position) : IsCheckmate p → ForcedWinIn 0 p.turn.other p
+| Self (n : Nat) (p : Position) (m : ChessMove) (p1 : Position) :
+   (m, p1) ∈ valid_moves p → ForcedWinIn n p.turn p1 → ForcedWinIn n.succ p.turn p
+| Opponent (n : Nat) (p : Position) :
+   (∀ vm ∈ valid_moves p, ForcedWinIn n p.turn.other vm.snd) → valid_moves p ≠ ∅ →
+    ForcedWinIn n p.turn.other p
+
+def forcedWinIn (n : Nat) (s : Side) (p : Position) : Bool :=
+  match n with
+  | 0 => IsCheckmate p && (p.turn ≠ s)
+  | n+1 =>
+      match p.turn == s with
+      | true =>
+          -- ∃ move leading to forced win in n
+          (valid_moves p).any (fun p1 => forcedWinIn n s p1.2) -- use p1.1 too!
+      | false =>
+          -- ∀ moves lead to forced win in n
+          (valid_moves p).all (fun p1 => forcedWinIn n s p1.2)
 
 --------------
 

--- a/Chess/Example218.lean
+++ b/Chess/Example218.lean
@@ -22,8 +22,15 @@ set_option linter.hashCommand false
 
 set_option maxRecDepth 1000
 theorem position_with_218_moves :
-    ForcedWin .black
+    ForcedNotLose .black
       example_5 := by
-  with_panel_widgets [ForcedWinWidget]
+  with_panel_widgets [ForcedNotLoseWidget]
     opponent_move -- at this point 218 goals are opened
     all_goals sorry
+
+theorem position_with_218_moves₀ :
+    ForcedNotLose .white
+      example_5 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    move "Qc2"
+    opponent_move

--- a/Chess/Example218.lean
+++ b/Chess/Example218.lean
@@ -25,12 +25,12 @@ theorem position_with_218_moves :
     ForcedNotLose .black
       example_5 := by
   with_panel_widgets [ForcedNotLoseWidget]
-    opponent_move -- at this point 218 goals are opened
+    opponent_moveNotLose -- at this point 218 goals are opened
     all_goals sorry
 
 theorem position_with_218_moves₀ :
     ForcedNotLose .white
       example_5 := by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "Qc2"
-    opponent_move
+    moveNotLose "Qc2"
+    opponent_moveNotLose

--- a/Chess/ExampleBKH.lean
+++ b/Chess/ExampleBKH.lean
@@ -2,6 +2,8 @@ import Chess.Basic
 import Chess.Tactics
 import Chess.Widgets
 import Chess.NextMoveTactic
+import Mathlib.Tactic.FinCases
+-- import Mathlib.Tactic.FunCases
 
 def example_5 :=
     ╔════════════════╗
@@ -40,27 +42,36 @@ theorem forcedWinDemo :
 theorem babsonNotStalemate :
     ForcedWin .white
       babsonTask := by
-  with_panel_widgets [ForcedNotLoseWidget]
+  with_panel_widgets [ForcedWinWidget]
     move "a7"
-    show ForcedWin _ _
-    have := @ForcedWin.Opponent babsonTask
-
     opponent_move
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
+    · move "R×f4"
+      checkmate
+    · move "B×c7"
+      opponent_move
+
+      sorry
+      sorry
+      sorry
+      sorry
+      sorry
+    · sorry
+    · sorry
+    · move "R×f4"
+      checkmate
+    · sorry
+    · sorry
+    · move "R×f4"
+      checkmate
+    · move "R×f4"
+      checkmate
+    · move "R×f4"
+      checkmate
+    · sorry
+    · sorry
+    · sorry
+    · sorry
+    · sorry
     · exact ne_of_beq_false rfl
 
 theorem babson :
@@ -74,24 +85,29 @@ theorem babson :
     opponent_moveNotLose
     · moveNotLose "R×f4"
       checkmateNotLose
+    · moveNotLose "B×c7"
+      opponent_moveNotLose
+      all_goals
+        moveNotLose "Q×b1"
+        opponent_moveNotLose
+        -- stalemate!
     · sorry
-    sorry
-    sorry
+    · sorry
     · moveNotLose "R×f4"
       checkmateNotLose
-    sorry
-    sorry
-    · moveNotLose "R×f4"
-      checkmateNotLose
+    · sorry
+    · sorry
     · moveNotLose "R×f4"
       checkmateNotLose
     · moveNotLose "R×f4"
       checkmateNotLose
-    sorry
-    sorry
-    sorry
-    sorry
-    sorry
+    · moveNotLose "R×f4"
+      checkmateNotLose
+    · sorry
+    · sorry
+    · sorry
+    · sorry
+    · sorry
 
 
 set_option maxRecDepth 1000
@@ -114,6 +130,91 @@ def example_6 :=
     ║▓▓♚]░░▓▓░░▓▓░░▓▓║
     ╚════════════════╝
 
+theorem position' :
+    ForcedWinIn 2 .white
+      example_6 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    moveIn "Rg2"
+    opponent_moveIn
+    · moveIn "Rh1"
+      checkmateIn
+    · moveIn "Rh1"
+      checkmateIn
+    · exact ne_of_beq_false rfl
+
+theorem position'' :
+    ¬ ForcedNotLose' .white
+      example_6 := by
+  intro hc
+  cases hc with
+  | Checkmate h g => sorry
+  | Opponent h g => sorry
+  | Self h m p1 g i => sorry
+
+theorem position''' :
+    ¬ IsCheckmate example_6 := by
+  decide
+
+set_option maxHeartbeats 0
+-- set_option maxRecDepth 10000000
+-- theorem babsonProof₀ :
+--     ¬ forcedWinIn 0 .white babsonTask := by -- DONE
+--   decide
+
+-- theorem babsonProof₁ :
+--     ¬ forcedWinIn 1 .white babsonTask := by -- DONE
+--   decide
+
+-- theorem babsonProof₂ :
+--     ¬ forcedWinIn 2 .white babsonTask := by -- DONE
+--   native_decide
+
+-- theorem babsonProof₃ :
+--     ¬ forcedWinIn 3 .white babsonTask := by -- DONE
+--   native_decide
+
+/-
+tactic 'native_decide' evaluated that the proposition
+  forcedWinIn 4 Side.white babsonTask = true
+is false
+-/
+-- theorem babsonProof₄ :
+--     ¬ forcedWinIn 4 .white babsonTask := by -- DONE
+--   native_decide
+
+
+-- theorem position'''' :
+--     ¬ forcedWinIn 2 .white example_6 := by
+-- --TODO: make the widgets work with `forcedWinIn`
+--   decide
+
+-- theorem position'''' :
+--     forcedWinIn 3 .white example_6 := by -- seems we have to count both players' of moves!
+-- --TODO: make the widgets work with `forcedWinIn`
+--   decide
+
+-- theorem babsonProof₄ :
+--     ¬ forcedWinIn 5 .white babsonTask := by
+--   native_decide
+
+theorem forcedWinIn_iff_ForcedWinIn (p : Position) (s : Side) (n : Nat) :
+    forcedWinIn n s p ↔ ForcedWinIn n s p := by
+    constructor
+    · induction n with
+    | zero =>
+        intro h
+        -- apply ForcedWinIn.Checkmate
+        sorry
+    | succ n _ => sorry
+    · induction n with
+    | zero =>
+        intro h
+        simp [forcedWinIn]
+
+        sorry
+    | succ n _ => sorry
+
+
 set_option maxRecDepth 1000
 theorem position :
     ForcedNotLose .white
@@ -124,6 +225,15 @@ theorem position :
     all_goals
     · moveNotLose "Rh1"
       checkmateNotLose
+
+theorem forcedWinDemo₁ :
+    ForcedWinIn 1 .white
+      example_5 := by
+  with_panel_widgets [ForcedWinWidget]
+    moveIn "Qb2"
+    checkmateIn
+-- TODO: Write a `ForcedWinIn 2` example.
+
 
 
 def example_7 :=

--- a/Chess/ExampleBKH.lean
+++ b/Chess/ExampleBKH.lean
@@ -33,21 +33,19 @@ set_option linter.hashCommand false
 theorem forcedWinDemo :
     ForcedWin .white
       example_5 := by
-  with_panel_widgets [ForcedNotLoseWidget]
-    moveNotStalemate "Qb2"
-    checkmateNotStalemate
--- TODO: rename "checkmate" to "checkmateNotLose" and "checkmateNotStalemate" to "checkmate"
-
+  with_panel_widgets [ForcedWinWidget]
+    move "Qb2"
+    checkmate
 
 theorem babsonNotStalemate :
     ForcedWin .white
       babsonTask := by
   with_panel_widgets [ForcedNotLoseWidget]
-    moveNotStalemate "a7"
+    move "a7"
     show ForcedWin _ _
     have := @ForcedWin.Opponent babsonTask
 
-    opponent_moveNotStalemate
+    opponent_move
     sorry
     sorry
     sorry
@@ -69,26 +67,26 @@ theorem babson :
     ForcedNotLose .white
       babsonTask := by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "a7"
+    moveNotLose "a7"
     show ForcedNotLose .white _
     have := @ForcedWin .white
     --sorry -- valid move exists
-    opponent_move
-    · move "R×f4"
-      checkmate
+    opponent_moveNotLose
+    · moveNotLose "R×f4"
+      checkmateNotLose
     · sorry
     sorry
     sorry
-    · move "R×f4"
-      checkmate
+    · moveNotLose "R×f4"
+      checkmateNotLose
     sorry
     sorry
-    · move "R×f4"
-      checkmate
-    · move "R×f4"
-      checkmate
-    · move "R×f4"
-      checkmate
+    · moveNotLose "R×f4"
+      checkmateNotLose
+    · moveNotLose "R×f4"
+      checkmateNotLose
+    · moveNotLose "R×f4"
+      checkmateNotLose
     sorry
     sorry
     sorry
@@ -101,8 +99,8 @@ theorem position_with_218_moves :
     ForcedNotLose .white
       example_5 := by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "Qa2"
-    checkmate
+    moveNotLose "Qa2"
+    checkmateNotLose
 
 def example_6 :=
     ╔════════════════╗
@@ -121,11 +119,11 @@ theorem position :
     ForcedNotLose .white
       example_6 := by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "Rg2"
-    opponent_move
+    moveNotLose "Rg2"
+    opponent_moveNotLose
     all_goals
-    · move "Rh1"
-      checkmate
+    · moveNotLose "Rh1"
+      checkmateNotLose
 
 
 def example_7 :=
@@ -179,9 +177,9 @@ theorem white_can_force_win_or_draw' :
     ForcedNotLose .white
       chatGPT_startingPosition := by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "e4"
+    moveNotLose "e4"
     have : 2 + 2 = 4 := by exact rfl
-    opponent_move
+    opponent_moveNotLose
     ·
       sorry
     sorry
@@ -210,8 +208,8 @@ theorem position7 :
     ForcedNotLose .white
       example_7 := by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "Rb4"
-    opponent_move -- really, a stalemate!
+    moveNotLose "Rb4"
+    opponent_moveNotLose -- really, a stalemate!
 
 theorem position7' :
     ForcedWin .white
@@ -224,19 +222,19 @@ theorem position7₀ :
     ForcedNotLose .white
       example_7 := by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "Rc4"
-    opponent_move
-    move "Rd5"
-    opponent_move
-    move "Rc1"
-    checkmate
+    moveNotLose "Rc4"
+    opponent_moveNotLose
+    moveNotLose "Rd5"
+    opponent_moveNotLose
+    moveNotLose "Rc1"
+    checkmateNotLose
 
 theorem position7₀_malikProof :
     ForcedNotLose .white
       example_7 := by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "Kb3"
-    opponent_move
+    moveNotLose "Kb3"
+    opponent_moveNotLose
     unfold example_7
-    move "Ra1"
-    checkmate
+    moveNotLose "Ra1"
+    checkmateNotLose

--- a/Chess/ExampleBKH.lean
+++ b/Chess/ExampleBKH.lean
@@ -1,0 +1,242 @@
+import Chess.Basic
+import Chess.Tactics
+import Chess.Widgets
+import Chess.NextMoveTactic
+
+def example_5 :=
+    ╔════════════════╗
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║░░▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║░░▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║♔}♕]░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║♚]▓▓░░▓▓░░▓▓░░▓▓║
+    ╚════════════════╝
+
+def babsonTask :=
+      ╔════════════════╗
+      ║♗]♛]░░♗]░░♔}░░▓▓║
+      ║▓▓░░▓▓♙]♟]♘]▓▓░░║
+      ║♙]▓▓░░▓▓♙]♟]░░▓▓║
+      ║♙]░░♟]░░▓▓♙]▓▓░░║
+      ║░░▓▓♙]♚]░░♝]░░♖]║
+      ║▓▓♟]▓▓░░▓▓░░▓▓░░║
+      ║♟]♘]░░♙]░░♙]░░▓▓║
+      ║♕]♖]▓▓░░▓▓░░▓▓░░║
+      ╚════════════════╝
+
+set_option linter.hashCommand false
+#widget ChessPositionWidget with { position? := example_5 : ChessPositionWidgetProps }
+
+theorem forcedWinDemo :
+    ForcedWin .white
+      example_5 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    moveNotStalemate "Qb2"
+    checkmateNotStalemate
+-- TODO: rename "checkmate" to "checkmateNotLose" and "checkmateNotStalemate" to "checkmate"
+
+
+theorem babsonNotStalemate :
+    ForcedWin .white
+      babsonTask := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    moveNotStalemate "a7"
+    show ForcedWin _ _
+    have := @ForcedWin.Opponent babsonTask
+
+    opponent_moveNotStalemate
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    · exact ne_of_beq_false rfl
+
+theorem babson :
+    ForcedNotLose .white
+      babsonTask := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    move "a7"
+    show ForcedNotLose .white _
+    have := @ForcedWin .white
+    --sorry -- valid move exists
+    opponent_move
+    · move "R×f4"
+      checkmate
+    · sorry
+    sorry
+    sorry
+    · move "R×f4"
+      checkmate
+    sorry
+    sorry
+    · move "R×f4"
+      checkmate
+    · move "R×f4"
+      checkmate
+    · move "R×f4"
+      checkmate
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+
+
+set_option maxRecDepth 1000
+theorem position_with_218_moves :
+    ForcedNotLose .white
+      example_5 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    move "Qa2"
+    checkmate
+
+def example_6 :=
+    ╔════════════════╗
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║░░▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║░░▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░♖]░░║
+    ║♔}▓▓░░▓▓░░▓▓░░♖]║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║▓▓♚]░░▓▓░░▓▓░░▓▓║
+    ╚════════════════╝
+
+set_option maxRecDepth 1000
+theorem position :
+    ForcedNotLose .white
+      example_6 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    move "Rg2"
+    opponent_move
+    all_goals
+    · move "Rh1"
+      checkmate
+
+
+def example_7 :=
+    ╔════════════════╗
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║░░▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║♖]▓▓░░▓▓░░▓▓░░▓▓║
+    ║♖]░░▓▓░░▓▓░░▓▓░░║
+    ║♔}▓▓░░▓▓░░▓▓░░▓▓║
+    ║▓▓░░▓▓░░▓▓░░▓▓░░║
+    ║♚]▓▓░░▓▓░░▓▓░░▓▓║
+    ╚════════════════╝
+#check example_7
+def chatGPT_startingPosition :=
+      ╔════════════════╗
+      ║♜]♞]♝]♛]♚]♝]♞]♜]║
+      ║♟]♟]♟]♟]♟]♟]♟]♟]║
+      ║░░▓▓░░▓▓░░▓▓░░▓▓║
+      ║▓▓░░▓▓░░▓▓░░▓▓░░║
+      ║░░▓▓░░▓▓░░▓▓░░▓▓║
+      ║▓▓░░▓▓░░▓▓░░▓▓░░║
+      ║♙]♙]♙]♙]♙]♙]♙]♙]║
+      ║♖]♘]♗]♕]♔}♗]♘]♖]║
+      ╚════════════════╝
+
+def canCastle :=
+      ╔════════════════╗
+      ║♜]░░♝]♛]♚]♝]░░♜]║
+      ║♟]♟]♟]♟]♟]♟]♟]♟]║
+      ║░░♞]░░▓▓░░♞]░░▓▓║
+      ║▓▓░░▓▓░░▓▓░░▓▓░░║
+      ║░░▓▓░░▓▓░░▓▓░░▓▓║
+      ║▓▓♘]▓▓░░▓▓♘]▓▓░░║
+      ║♙]♙]♙]♙]♙]♙]♙]♙]║
+      ║♖]░░♗]♕]♔}░░░░♖]║
+      ╚════════════════╝
+
+set_option maxRecDepth 1000
+theorem white_can_force_win_or_draw :
+    ForcedWin .white
+      canCastle := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    unfold canCastle
+    -- move "O-O"
+    have : 2 + 2 = 4 := by exact rfl
+    sorry
+
+
+theorem white_can_force_win_or_draw' :
+    ForcedNotLose .white
+      chatGPT_startingPosition := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    move "e4"
+    have : 2 + 2 = 4 := by exact rfl
+    opponent_move
+    ·
+      sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+    sorry
+
+
+set_option maxRecDepth 1000
+theorem position7 :
+    ForcedNotLose .white
+      example_7 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    move "Rb4"
+    opponent_move -- really, a stalemate!
+
+theorem position7' :
+    ForcedWin .white
+      example_7 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    sorry
+
+
+theorem position7₀ :
+    ForcedNotLose .white
+      example_7 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    move "Rc4"
+    opponent_move
+    move "Rd5"
+    opponent_move
+    move "Rc1"
+    checkmate
+
+theorem position7₀_malikProof :
+    ForcedNotLose .white
+      example_7 := by
+  with_panel_widgets [ForcedNotLoseWidget]
+    move "Kb3"
+    opponent_move
+    unfold example_7
+    move "Ra1"
+    checkmate

--- a/Chess/Examples.lean
+++ b/Chess/Examples.lean
@@ -15,8 +15,8 @@ theorem black_wins_back_rank :
       ║♙]♙]♙]▓▓░░♙]♙]♙]║
       ║▓▓░░▓▓░░▓▓░░♔]░░║
       ╚════════════════╝ := by
-  move "Re1"
-  checkmate
+  moveNotLose "Re1"
+  checkmateNotLose
 
 theorem white_wins_promotion_back_rank :
     ForcedNotLose .white
@@ -30,8 +30,8 @@ theorem white_wins_promotion_back_rank :
       ║♙]♙]░░▓▓░░♙]♙]♙]║
       ║▓▓░░▓▓░░▓▓░░♔}░░║
       ╚════════════════╝ := by
-  move "c8=R"
-  checkmate
+  moveNotLose "c8=R"
+  checkmateNotLose
 
 theorem black_wins_promotion :
     ForcedNotLose .black
@@ -45,8 +45,8 @@ theorem black_wins_promotion :
       ║♙]♙]░░▓▓♟]♙]♔]♙]║
       ║▓▓░░▓▓░░▓▓♘]♖]♖]║
       ╚════════════════╝ := by
-  move "e1=N"
-  checkmate
+  moveNotLose "e1=N"
+  checkmateNotLose
 
 set_option linter.hashCommand false
 #widget ChessPositionWidget with { position? := some <| get_pos black_wins_promotion : ChessPositionWidgetProps }
@@ -68,14 +68,14 @@ theorem smothered_mate :
       ║░░▓▓░░▓▓░░▓▓♔}▓▓║
       ╚════════════════╝ := by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "Nf7"
-    opponent_move
-    move "Nh6"
-    opponent_move
-    move "Qg8"
-    opponent_move
-    move "Nf7"
-    checkmate
+    moveNotLose "Nf7"
+    opponent_moveNotLose
+    moveNotLose "Nh6"
+    opponent_moveNotLose
+    moveNotLose "Qg8"
+    opponent_moveNotLose
+    moveNotLose "Nf7"
+    checkmateNotLose
 /--
 Gunnar Gundersen vs. A H Faul
 1-0 Pietzcker Christmas Tournament Melbourne AUS 1928
@@ -93,8 +93,8 @@ theorem en_passant_mate :
     ║♖]▓▓♗]▓▓♔}▓▓░░♖]║
     ╚════════════════╝:= by
   with_panel_widgets [ForcedNotLoseWidget]
-    move "h×g6"
-    checkmate
+    moveNotLose "h×g6"
+    checkmateNotLose
 
 /-
 set_option maxHeartbeats 3000000 in

--- a/Chess/Examples.lean
+++ b/Chess/Examples.lean
@@ -4,7 +4,7 @@ import Chess.Widgets
 
 
 theorem black_wins_back_rank :
-    ForcedWin .black
+    ForcedNotLose .black
       ╔════════════════╗
       ║░░▓▓░░▓▓♜]▓▓♚}▓▓║
       ║♟]░░▓▓░░▓▓♟]♟]♟]║
@@ -19,7 +19,7 @@ theorem black_wins_back_rank :
   checkmate
 
 theorem white_wins_promotion_back_rank :
-    ForcedWin .white
+    ForcedNotLose .white
       ╔════════════════╗
       ║░░▓▓░░▓▓░░▓▓♚]▓▓║
       ║♟]░░♙]░░▓▓♟]♟]♟]║
@@ -34,7 +34,7 @@ theorem white_wins_promotion_back_rank :
   checkmate
 
 theorem black_wins_promotion :
-    ForcedWin .black
+    ForcedNotLose .black
       ╔════════════════╗
       ║░░▓▓░░▓▓░░▓▓♚}▓▓║
       ║♟]░░▓▓░░▓▓♟]♟]♟]║
@@ -56,7 +56,7 @@ Timman-Short 1990
 (from https://en.wikipedia.org/wiki/Smothered_mate)
 -/
 theorem smothered_mate :
-    ForcedWin .white
+    ForcedNotLose .white
       ╔════════════════╗
       ║▓▓░░▓▓░░♜]░░▓▓♚]║
       ║♟]▓▓♟]♖]♙]▓▓♟]♟]║
@@ -67,7 +67,7 @@ theorem smothered_mate :
       ║♙]░░▓▓░░♙]♙]▓▓♙]║
       ║░░▓▓░░▓▓░░▓▓♔}▓▓║
       ╚════════════════╝ := by
-  with_panel_widgets [ForcedWinWidget]
+  with_panel_widgets [ForcedNotLoseWidget]
     move "Nf7"
     opponent_move
     move "Nh6"
@@ -81,7 +81,7 @@ Gunnar Gundersen vs. A H Faul
 1-0 Pietzcker Christmas Tournament Melbourne AUS 1928
 -/
 theorem en_passant_mate :
-    ForcedWin .white
+    ForcedNotLose .white
     ╔════════════════╗
     ║♜]░░♝]♛]▓▓♜]▓▓░░║
     ║♟]♟]░░▓▓♞]▓▓░░▓▓║
@@ -92,7 +92,7 @@ theorem en_passant_mate :
     ║♙]♙]▓▓░░▓▓♙]♙]░░║
     ║♖]▓▓♗]▓▓♔}▓▓░░♖]║
     ╚════════════════╝:= by
-  with_panel_widgets [ForcedWinWidget]
+  with_panel_widgets [ForcedNotLoseWidget]
     move "h×g6"
     checkmate
 

--- a/Chess/NextMoveExamples.lean
+++ b/Chess/NextMoveExamples.lean
@@ -5,7 +5,7 @@ import Chess.NextMoveTactic
 
 
 theorem smothered_mate' :
-    ForcedWin .white
+    ForcedNotLose .white
       ╔════════════════╗
       ║▓▓░░▓▓░░♜]░░▓▓♚]║
       ║♟]▓▓♟]♖]♙]▓▓♟]♟]║
@@ -16,7 +16,7 @@ theorem smothered_mate' :
       ║♙]░░▓▓░░♙]♙]▓▓♙]║
       ║░░▓▓░░▓▓░░▓▓♔}▓▓║
       ╚════════════════╝ := by
-  with_panel_widgets [ForcedWinWidget]
+  with_panel_widgets [ForcedNotLoseWidget]
     guess_next_move
     opponent_move
     guess_next_move

--- a/Chess/NextMoveExamples.lean
+++ b/Chess/NextMoveExamples.lean
@@ -4,7 +4,7 @@ import Chess.Widgets
 import Chess.NextMoveTactic
 
 
-theorem smothered_mate' :
+theorem smothered_mate'NotLose :
     ForcedNotLose .white
       ╔════════════════╗
       ║▓▓░░▓▓░░♜]░░▓▓♚]║
@@ -17,6 +17,28 @@ theorem smothered_mate' :
       ║░░▓▓░░▓▓░░▓▓♔}▓▓║
       ╚════════════════╝ := by
   with_panel_widgets [ForcedNotLoseWidget]
+    guess_next_moveNotLose
+    opponent_moveNotLose
+    guess_next_moveNotLose
+    opponent_moveNotLose
+    guess_next_moveNotLose
+    opponent_moveNotLose
+    guess_next_moveNotLose
+    checkmateNotLose
+
+theorem smothered_mate' :
+    ForcedWin .white
+      ╔════════════════╗
+      ║▓▓░░▓▓░░♜]░░▓▓♚]║
+      ║♟]▓▓♟]♖]♙]▓▓♟]♟]║
+      ║▓▓░░♟]░░▓▓░░▓▓░░║
+      ║░░▓▓░░▓▓░░♟]♘]▓▓║
+      ║▓▓░░♕]░░▓▓░░♞]░░║
+      ║♛]▓▓░░▓▓░░▓▓♙]▓▓║
+      ║♙]░░▓▓░░♙]♙]▓▓♙]║
+      ║░░▓▓░░▓▓░░▓▓♔}▓▓║
+      ╚════════════════╝ := by
+  with_panel_widgets [ForcedWinWidget]
     guess_next_move
     opponent_move
     guess_next_move
@@ -25,3 +47,5 @@ theorem smothered_mate' :
     opponent_move
     guess_next_move
     checkmate
+    all_goals
+      exact ne_of_beq_false rfl

--- a/Chess/NextMoveTactic.lean
+++ b/Chess/NextMoveTactic.lean
@@ -23,8 +23,8 @@ def callNextMoveScript (input : String): IO String := do
 elab "guess_next_move" : tactic => do
   -- Get the current goal
   let goal ← getMainGoal
-  -- Extract the position from a `ForcedWin` goal
-  let posOpt ← extractPositionFromForcedWinGoal goal
+  -- Extract the position from a `ForcedNotLose` goal
+  let posOpt ← extractPositionFromForcedNotLoseGoal goal
   match posOpt with
   | some posVal =>
     -- Convert the position to a FEN string
@@ -45,4 +45,4 @@ elab "guess_next_move" : tactic => do
 
       -- Execute the parsed tactic
       evalTactic stx
-  | none => throwError "No ForcedWin goal found or invalid goal type."
+  | none => throwError "No ForcedNotLose goal found or invalid goal type."

--- a/Chess/NextMoveTactic.lean
+++ b/Chess/NextMoveTactic.lean
@@ -4,6 +4,16 @@ import Chess.Widgets
 open Lean Meta Elab Tactic Chess
 
 /-- Calls an external Python script and retrieves its output. -/
+def callNextMoveScriptNotLose (input : String): IO String := do
+  let path := ("./scripts/get_next_move.py" : System.FilePath)
+  unless ← path.pathExists do
+    throw <| IO.userError s!"Python script '{path}' not found."
+  let out ← IO.Process.output { cmd := "python3", args := #[path.toString, input] }
+  if out.exitCode != 0 then
+    throw <| IO.userError s!"Script '{path}' exited with code {out.exitCode}:\n{out.stderr}"
+  return "moveNotLose \"" ++ out.stdout.trim ++ "\""
+
+/-- Calls an external Python script and retrieves its output. -/
 def callNextMoveScript (input : String): IO String := do
   let path := ("./scripts/get_next_move.py" : System.FilePath)
   unless ← path.pathExists do
@@ -20,11 +30,39 @@ def callNextMoveScript (input : String): IO String := do
     sudo apt install stockfish
     ```
     -/
-elab "guess_next_move" : tactic => do
+elab "guess_next_moveNotLose" : tactic => do
   -- Get the current goal
   let goal ← getMainGoal
   -- Extract the position from a `ForcedNotLose` goal
   let posOpt ← extractPositionFromForcedNotLoseGoal goal
+  match posOpt with
+  | some posVal =>
+    -- Convert the position to a FEN string
+    let fenStr := fenFromPosition posVal
+    -- Pass the FEN string to the Python script
+    let nextMove ← liftM <| callNextMoveScriptNotLose fenStr
+
+    -- Log the output for debugging
+    -- logInfo s!"Python script output: {nextMove}"
+
+    -- Interpret the Python output as Lean syntax and apply it
+    let env ← getEnv
+    match Parser.runParserCategory env `tactic nextMove with
+    | Except.error errMsg => throwError s!"Failed to parse tactic from Python script: {errMsg}"
+    | Except.ok stx => do
+      -- Add the suggestion to the tactic
+      Lean.Meta.Tactic.TryThis.addSuggestion (← getRef) nextMove
+
+      -- Execute the parsed tactic
+      evalTactic stx
+  | none => throwError "No ForcedNotLose goal found or invalid goal type."
+
+
+elab "guess_next_move" : tactic => do
+  -- Get the current goal
+  let goal ← getMainGoal
+  -- Extract the position from a `ForcedWin` goal
+  let posOpt ← extractPositionFromForcedWinGoal goal
   match posOpt with
   | some posVal =>
     -- Convert the position to a FEN string

--- a/Chess/Tactics.lean
+++ b/Chess/Tactics.lean
@@ -11,8 +11,68 @@ syntax "move " term : tactic
 elab_rules : tactic | `(tactic| move $t:term) => withMainContext do
   let g ← getMainGoal
   let goal_type ← whnfR (← g.getType)
+  let .app (.app (.const ``ForcedNotLose _) side) pos := goal_type
+    | throwError "'move' tactic expects ForcedNotLose goal"
+  let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
+  if not (← Lean.Meta.isExprDefEq side posTurn) then
+    throwError "It is {side}'s turn to move, try to use the `opponent_move` tactic instead of `move`"
+  let t ← Lean.Elab.Term.elabTerm t none
+  let cm ← whnf (← mkAppM ``ChessMove.ofString #[t])
+  let .app (.app (.const ``Option.some _) _) cm := cm
+    | throwError "failed to parse move"
+
+  let pos1 ← whnf (← mkAppM ``make_move #[pos, cm])
+  let .app (.app (.const ``Option.some _) _) pos1 := pos1
+    | throwError "failed to make move"
+  let pos1 ← whnf pos1
+
+  let pos_stx ← Lean.Elab.Term.exprToSyntax pos
+  let mv_stx ← Lean.Elab.Term.exprToSyntax cm
+  let pos1_stx ← Lean.Elab.Term.exprToSyntax pos1
+  evalTactic (← `(tactic| refine ForcedNotLose.Self $pos_stx $mv_stx $pos1_stx (by decide) ?_))
+  evalTactic (← `(tactic| dsimp [game_start, Side.other, Position.set]))
+
+syntax "opponent_move" : tactic
+
+elab_rules : tactic | `(tactic| opponent_move) => withMainContext do
+  let g ← getMainGoal
+  let goal_type ← whnfR (← g.getType)
+  let .app (.app (.const ``ForcedNotLose _) side) pos := goal_type
+    | throwError "'opponent_move' tactic expects ForcedNotLose goal"
+  let pos_stx ← Lean.Elab.Term.exprToSyntax pos
+  let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
+  if (← Lean.Meta.isExprDefEq side posTurn) then
+    throwError "It is {side}'s turn to move, try to use the `move` tactic instead of `opponent_move`"
+  evalTactic (← `(tactic| apply ForcedNotLose.Opponent $pos_stx))
+  evalTactic (← `(tactic| rw [←List.forall_iff_forall_mem]))
+  evalTactic (← `(tactic| dsimp [do_simple_move, Side.other, Position.set]))
+  evalTactic (← `(tactic| try constructorm* (_ ∧ _)))
+  for g in (←get).goals do
+    g.setUserName .anonymous
+
+syntax "checkmate" : tactic
+
+elab_rules : tactic | `(tactic| checkmate) => withMainContext do
+  let g ← getMainGoal
+  let goal_type ← whnfR (← g.getType)
+  let .app (.app (.const ``ForcedNotLose _) side) pos := goal_type
+    | throwError "'checkmate' tactic expects ForcedNotLose goal"
+  let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
+  if (← Lean.Meta.isExprDefEq side posTurn) then
+    throwError "It is {side}'s turn to move, try to use the `move` tactic instead to make a move that checkmates"
+
+  let pos_stx ← Lean.Elab.Term.exprToSyntax pos
+  evalTactic (← `(tactic| exact ForcedNotLose.Checkmate $pos_stx (by decide)))
+
+
+
+syntax "moveNotStalemate " term : tactic
+
+elab_rules : tactic | `(tactic| moveNotStalemate $t:term) => withMainContext do
+  let g ← getMainGoal
+  let goal_type ← whnfR (← g.getType)
   let .app (.app (.const ``ForcedWin _) side) pos := goal_type
-    | throwError "'move' tactic expects ForcedWin goal"
+    | throwError "'moveNotStalemate' tactic expects ForcedWin goal"
   let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
   if not (← Lean.Meta.isExprDefEq side posTurn) then
     throwError "It is {side}'s turn to move, try to use the `opponent_move` tactic instead of `move`"
@@ -32,13 +92,14 @@ elab_rules : tactic | `(tactic| move $t:term) => withMainContext do
   evalTactic (← `(tactic| refine ForcedWin.Self $pos_stx $mv_stx $pos1_stx (by decide) ?_))
   evalTactic (← `(tactic| dsimp [game_start, Side.other, Position.set]))
 
-syntax "opponent_move" : tactic
 
-elab_rules : tactic | `(tactic| opponent_move) => withMainContext do
+syntax "opponent_moveNotStalemate" : tactic
+
+elab_rules : tactic | `(tactic| opponent_moveNotStalemate) => withMainContext do
   let g ← getMainGoal
   let goal_type ← whnfR (← g.getType)
   let .app (.app (.const ``ForcedWin _) side) pos := goal_type
-    | throwError "'opponent_move' tactic expects ForcedWin goal"
+    | throwError "'opponent_moveNotStalemate' tactic expects ForcedWin goal"
   let pos_stx ← Lean.Elab.Term.exprToSyntax pos
   let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
   if (← Lean.Meta.isExprDefEq side posTurn) then
@@ -50,16 +111,17 @@ elab_rules : tactic | `(tactic| opponent_move) => withMainContext do
   for g in (←get).goals do
     g.setUserName .anonymous
 
-syntax "checkmate" : tactic
 
-elab_rules : tactic | `(tactic| checkmate) => withMainContext do
+syntax "checkmateNotStalemate" : tactic
+
+elab_rules : tactic | `(tactic| checkmateNotStalemate) => withMainContext do
   let g ← getMainGoal
   let goal_type ← whnfR (← g.getType)
   let .app (.app (.const ``ForcedWin _) side) pos := goal_type
-    | throwError "'checkmate' tactic expects ForcedWin goal"
+    | throwError "'checkmateNotStalemate' tactic expects ForcedWin goal"
   let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
   if (← Lean.Meta.isExprDefEq side posTurn) then
-    throwError "It is {side}'s turn to move, try to use the `move` tactic instead to make a move that checkmates"
+    throwError "It is {side}'s turn to move, try to use the `moveNotStalemate` tactic instead to make a move that checkmates"
 
   let pos_stx ← Lean.Elab.Term.exprToSyntax pos
   evalTactic (← `(tactic| exact ForcedWin.Checkmate $pos_stx (by decide)))

--- a/Chess/Tactics.lean
+++ b/Chess/Tactics.lean
@@ -92,6 +92,33 @@ elab_rules : tactic | `(tactic| move $t:term) => withMainContext do
   evalTactic (← `(tactic| refine ForcedWin.Self $pos_stx $mv_stx $pos1_stx (by decide) ?_))
   evalTactic (← `(tactic| dsimp [game_start, Side.other, Position.set]))
 
+syntax "moveIn " term : tactic
+
+elab_rules : tactic | `(tactic| moveIn $t:term) => withMainContext do
+  let g ← getMainGoal
+  let goal_type ← whnfR (← g.getType)
+  let .app (.app (.app (.const ``ForcedWinIn _) n) side) pos := goal_type --thanks ChatGPT
+    | throwError "'moveIn' tactic expects ForcedWinIn goal"
+  let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
+  if not (← Lean.Meta.isExprDefEq side posTurn) then
+    throwError "It is {side}'s turn to move, try to use the `opponent_move` tactic instead of `move`"
+  let t ← Lean.Elab.Term.elabTerm t none
+  let cm ← whnf (← mkAppM ``ChessMove.ofString #[t])
+  let .app (.app (.const ``Option.some _) _) cm := cm
+    | throwError "failed to parse move"
+
+  let pos1 ← whnf (← mkAppM ``make_move #[pos, cm])
+  let .app (.app (.const ``Option.some _) _) pos1 := pos1
+    | throwError "failed to make move"
+  let pos1 ← whnf pos1
+  let nPred ← mkAppM ``Nat.pred #[n]
+  let nP ← Lean.Elab.Term.exprToSyntax nPred
+  let pos_stx ← Lean.Elab.Term.exprToSyntax pos
+  let mv_stx ← Lean.Elab.Term.exprToSyntax cm
+  let pos1_stx ← Lean.Elab.Term.exprToSyntax pos1
+  evalTactic (← `(tactic| refine ForcedWinIn.Self $nP $pos_stx $mv_stx $pos1_stx (by decide) ?_))
+  evalTactic (← `(tactic| dsimp [game_start, Side.other, Position.set]))
+
 
 syntax "opponent_move" : tactic
 
@@ -105,6 +132,26 @@ elab_rules : tactic | `(tactic| opponent_move) => withMainContext do
   if (← Lean.Meta.isExprDefEq side posTurn) then
     throwError "It is {side}'s turn to move, try to use the `move` tactic instead of `opponent_move`"
   evalTactic (← `(tactic| apply ForcedWin.Opponent $pos_stx))
+  evalTactic (← `(tactic| rw [←List.forall_iff_forall_mem]))
+  evalTactic (← `(tactic| dsimp [do_simple_move, Side.other, Position.set]))
+  evalTactic (← `(tactic| try constructorm* (_ ∧ _)))
+  for g in (←get).goals do
+    g.setUserName .anonymous
+
+syntax "opponent_moveIn" : tactic
+
+elab_rules : tactic | `(tactic| opponent_moveIn) => withMainContext do
+  let g ← getMainGoal
+  let goal_type ← whnfR (← g.getType)
+  let .app (.app (.app (.const ``ForcedWinIn _) n) side) pos := goal_type --thanks ChatGPT
+    | throwError "'opponent_moveIn' tactic expects ForcedWinIn goal"
+  let nP ← Lean.Elab.Term.exprToSyntax n
+
+  let pos_stx ← Lean.Elab.Term.exprToSyntax pos
+  let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
+  if (← Lean.Meta.isExprDefEq side posTurn) then
+    throwError "It is {side}'s turn to move, try to use the `move` tactic instead of `opponent_move`"
+  evalTactic (← `(tactic| apply ForcedWinIn.Opponent $nP $pos_stx))
   evalTactic (← `(tactic| rw [←List.forall_iff_forall_mem]))
   evalTactic (← `(tactic| dsimp [do_simple_move, Side.other, Position.set]))
   evalTactic (← `(tactic| try constructorm* (_ ∧ _)))
@@ -125,5 +172,25 @@ elab_rules : tactic | `(tactic| checkmate) => withMainContext do
 
   let pos_stx ← Lean.Elab.Term.exprToSyntax pos
   evalTactic (← `(tactic| exact ForcedWin.Checkmate $pos_stx (by decide)))
+
+syntax "checkmateIn" : tactic
+
+elab_rules : tactic | `(tactic| checkmateIn) => withMainContext do
+  let g ← getMainGoal
+  let goal_type ← whnfR (← g.getType)
+  let .app (.app (.app (.const ``ForcedWinIn _) _) side) pos := goal_type --thanks ChatGPT
+    | throwError "'checkmateIn' tactic expects ForcedWinIn goal"
+  let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
+  if (← Lean.Meta.isExprDefEq side posTurn) then
+    throwError "It is {side}'s turn to move, try to use the `move` tactic instead to make a move that checkmates"
+
+  -- if n.rawNatLit? ≠ some 0 then
+  --   throwError "'checkmateIn' tactic requires n = 0 but received {n.rawNatLit?}"
+  -- let nPred ← mkAppM ``Nat.pred #[n]
+  -- let nP ← Lean.Elab.Term.exprToSyntax nPred
+
+
+  let pos_stx ← Lean.Elab.Term.exprToSyntax pos
+  evalTactic (← `(tactic| exact ForcedWinIn.Checkmate $pos_stx (by decide)))
 
 end tactics

--- a/Chess/Tactics.lean
+++ b/Chess/Tactics.lean
@@ -6,16 +6,16 @@ section tactics
 
 open Lean.Meta Lean.Elab.Tactic
 
-syntax "move " term : tactic
+syntax "moveNotLose " term : tactic
 
-elab_rules : tactic | `(tactic| move $t:term) => withMainContext do
+elab_rules : tactic | `(tactic| moveNotLose $t:term) => withMainContext do
   let g ← getMainGoal
   let goal_type ← whnfR (← g.getType)
   let .app (.app (.const ``ForcedNotLose _) side) pos := goal_type
-    | throwError "'move' tactic expects ForcedNotLose goal"
+    | throwError "moveNotLose' tactic expects ForcedNotLose goal"
   let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
   if not (← Lean.Meta.isExprDefEq side posTurn) then
-    throwError "It is {side}'s turn to move, try to use the `opponent_move` tactic instead of `move`"
+    throwError "It is {side}'s turn to move, try to use the `opponent_moveNotLose` tactic instead of `moveNotLose`"
   let t ← Lean.Elab.Term.elabTerm t none
   let cm ← whnf (← mkAppM ``ChessMove.ofString #[t])
   let .app (.app (.const ``Option.some _) _) cm := cm
@@ -32,17 +32,17 @@ elab_rules : tactic | `(tactic| move $t:term) => withMainContext do
   evalTactic (← `(tactic| refine ForcedNotLose.Self $pos_stx $mv_stx $pos1_stx (by decide) ?_))
   evalTactic (← `(tactic| dsimp [game_start, Side.other, Position.set]))
 
-syntax "opponent_move" : tactic
+syntax "opponent_moveNotLose" : tactic
 
-elab_rules : tactic | `(tactic| opponent_move) => withMainContext do
+elab_rules : tactic | `(tactic| opponent_moveNotLose) => withMainContext do
   let g ← getMainGoal
   let goal_type ← whnfR (← g.getType)
   let .app (.app (.const ``ForcedNotLose _) side) pos := goal_type
-    | throwError "'opponent_move' tactic expects ForcedNotLose goal"
+    | throwError "'opponent_moveNotLose' tactic expects ForcedNotLose goal"
   let pos_stx ← Lean.Elab.Term.exprToSyntax pos
   let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
   if (← Lean.Meta.isExprDefEq side posTurn) then
-    throwError "It is {side}'s turn to move, try to use the `move` tactic instead of `opponent_move`"
+    throwError "It is {side}'s turn to move, try to use the `moveNotLose` tactic instead of `opponent_moveNotLose`"
   evalTactic (← `(tactic| apply ForcedNotLose.Opponent $pos_stx))
   evalTactic (← `(tactic| rw [←List.forall_iff_forall_mem]))
   evalTactic (← `(tactic| dsimp [do_simple_move, Side.other, Position.set]))
@@ -50,13 +50,13 @@ elab_rules : tactic | `(tactic| opponent_move) => withMainContext do
   for g in (←get).goals do
     g.setUserName .anonymous
 
-syntax "checkmate" : tactic
+syntax "checkmateNotLose" : tactic
 
-elab_rules : tactic | `(tactic| checkmate) => withMainContext do
+elab_rules : tactic | `(tactic| checkmateNotLose) => withMainContext do
   let g ← getMainGoal
   let goal_type ← whnfR (← g.getType)
   let .app (.app (.const ``ForcedNotLose _) side) pos := goal_type
-    | throwError "'checkmate' tactic expects ForcedNotLose goal"
+    | throwError "'checkmateNotLose' tactic expects ForcedNotLose goal"
   let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
   if (← Lean.Meta.isExprDefEq side posTurn) then
     throwError "It is {side}'s turn to move, try to use the `move` tactic instead to make a move that checkmates"
@@ -66,13 +66,13 @@ elab_rules : tactic | `(tactic| checkmate) => withMainContext do
 
 
 
-syntax "moveNotStalemate " term : tactic
+syntax "move " term : tactic
 
-elab_rules : tactic | `(tactic| moveNotStalemate $t:term) => withMainContext do
+elab_rules : tactic | `(tactic| move $t:term) => withMainContext do
   let g ← getMainGoal
   let goal_type ← whnfR (← g.getType)
   let .app (.app (.const ``ForcedWin _) side) pos := goal_type
-    | throwError "'moveNotStalemate' tactic expects ForcedWin goal"
+    | throwError "'move' tactic expects ForcedWin goal"
   let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
   if not (← Lean.Meta.isExprDefEq side posTurn) then
     throwError "It is {side}'s turn to move, try to use the `opponent_move` tactic instead of `move`"
@@ -93,13 +93,13 @@ elab_rules : tactic | `(tactic| moveNotStalemate $t:term) => withMainContext do
   evalTactic (← `(tactic| dsimp [game_start, Side.other, Position.set]))
 
 
-syntax "opponent_moveNotStalemate" : tactic
+syntax "opponent_move" : tactic
 
-elab_rules : tactic | `(tactic| opponent_moveNotStalemate) => withMainContext do
+elab_rules : tactic | `(tactic| opponent_move) => withMainContext do
   let g ← getMainGoal
   let goal_type ← whnfR (← g.getType)
   let .app (.app (.const ``ForcedWin _) side) pos := goal_type
-    | throwError "'opponent_moveNotStalemate' tactic expects ForcedWin goal"
+    | throwError "'opponent_move' tactic expects ForcedWin goal"
   let pos_stx ← Lean.Elab.Term.exprToSyntax pos
   let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
   if (← Lean.Meta.isExprDefEq side posTurn) then
@@ -112,16 +112,16 @@ elab_rules : tactic | `(tactic| opponent_moveNotStalemate) => withMainContext do
     g.setUserName .anonymous
 
 
-syntax "checkmateNotStalemate" : tactic
+syntax "checkmate" : tactic
 
-elab_rules : tactic | `(tactic| checkmateNotStalemate) => withMainContext do
+elab_rules : tactic | `(tactic| checkmate) => withMainContext do
   let g ← getMainGoal
   let goal_type ← whnfR (← g.getType)
   let .app (.app (.const ``ForcedWin _) side) pos := goal_type
-    | throwError "'checkmateNotStalemate' tactic expects ForcedWin goal"
+    | throwError "'checkmate' tactic expects ForcedWin goal"
   let posTurn ← whnfR (← mkAppM ``Position.turn #[pos])
   if (← Lean.Meta.isExprDefEq side posTurn) then
-    throwError "It is {side}'s turn to move, try to use the `moveNotStalemate` tactic instead to make a move that checkmates"
+    throwError "It is {side}'s turn to move, try to use the `move` tactic instead to make a move that checkmates"
 
   let pos_stx ← Lean.Elab.Term.exprToSyntax pos
   evalTactic (← `(tactic| exact ForcedWin.Checkmate $pos_stx (by decide)))

--- a/Chess/TacticsTest.lean
+++ b/Chess/TacticsTest.lean
@@ -3,7 +3,7 @@ import Chess.Tactics
 /-- error: It is Side.black's turn to move, try to use the `move` tactic instead of `opponent_move` -/
 #guard_msgs in
 theorem black_wins_back_rank :
-    ForcedWin .black
+    ForcedNotLose .black
       ╔════════════════╗
       ║░░▓▓░░▓▓♜]▓▓♚}▓▓║
       ║♟]░░▓▓░░▓▓♟]♟]♟]║
@@ -24,7 +24,7 @@ Timman-Short 1990
 (from https://en.wikipedia.org/wiki/Smothered_mate)
 -/
 theorem smothered_mate :
-    ForcedWin .white
+    ForcedNotLose .white
       ╔════════════════╗
       ║▓▓░░▓▓░░♜]░░▓▓♚]║
       ║♟]▓▓♟]♖]♙]▓▓♟]♟]║
@@ -41,7 +41,7 @@ theorem smothered_mate :
 /-- error: It is Side.white's turn to move, try to use the `move` tactic instead to make a move that checkmates -/
 #guard_msgs in
 theorem white_wins_promotion_back_rank :
-    ForcedWin .white
+    ForcedNotLose .white
       ╔════════════════╗
       ║░░▓▓░░▓▓░░▓▓♚]▓▓║
       ║♟]░░♙]░░▓▓♟]♟]♟]║

--- a/Chess/TacticsTest.lean
+++ b/Chess/TacticsTest.lean
@@ -1,6 +1,8 @@
 import Chess.Tactics
 
-/-- error: It is Side.black's turn to move, try to use the `move` tactic instead of `opponent_move` -/
+/-- error:
+It is Side.black's turn to move, try to use the `moveNotLose` tactic instead of `opponent_moveNotLose`
+-/
 #guard_msgs in
 theorem black_wins_back_rank :
     ForcedNotLose .black
@@ -14,15 +16,17 @@ theorem black_wins_back_rank :
       ║♙]♙]♙]▓▓░░♙]♙]♙]║
       ║▓▓░░▓▓░░▓▓░░♔]░░║
       ╚════════════════╝ := by
-  opponent_move
-  checkmate
+  opponent_moveNotLose
+  checkmateNotLose
 
-/-- error: It is Side.white's turn to move, try to use the `opponent_move` tactic instead of `move` -/
-#guard_msgs in
-/--
+/-
 Timman-Short 1990
 (from https://en.wikipedia.org/wiki/Smothered_mate)
 -/
+/--
+error: It is Side.white's turn to move, try to use the `opponent_moveNotLose` tactic instead of `moveNotLose`
+-/
+#guard_msgs in
 theorem smothered_mate :
     ForcedNotLose .white
       ╔════════════════╗
@@ -35,8 +39,8 @@ theorem smothered_mate :
       ║♙]░░▓▓░░♙]♙]▓▓♙]║
       ║░░▓▓░░▓▓░░▓▓♔}▓▓║
       ╚════════════════╝ := by
-    move "Nf7"
-    move "Nh6"
+    moveNotLose "Nf7"
+    moveNotLose "Nh6"
 
 /-- error: It is Side.white's turn to move, try to use the `move` tactic instead to make a move that checkmates -/
 #guard_msgs in
@@ -52,4 +56,4 @@ theorem white_wins_promotion_back_rank :
       ║♙]♙]░░▓▓░░♙]♙]♙]║
       ║▓▓░░▓▓░░▓▓░░♔}░░║
       ╚════════════════╝ := by
-  checkmate
+  checkmateNotLose

--- a/Chess/Widgets.lean
+++ b/Chess/Widgets.lean
@@ -31,7 +31,7 @@ const pieceSymbols = {
 
 // Helper function to determine the square color
 function getSquareColor(row, col) {
-  return (row + col) % 2 === 0 ? '#b58863' : '#f0d9b5';
+  return (row + col) % 2 === 1 ? '#b58863' : '#f0d9b5';
 }
 
 // Chessboard component with inline styles

--- a/Chess/Widgets.lean
+++ b/Chess/Widgets.lean
@@ -101,9 +101,9 @@ export default function ChessPositionWidget(props) {
 
 open Lean Meta Elab
 
-def get_pos {p : _root_.Position} {side : Side} (_: ForcedWin side p) : _root_.Position := p
+def get_pos {p : _root_.Position} {side : Side} (_: ForcedNotLose side p) : _root_.Position := p
 
-def get_side {p : _root_.Position} {side : Side} (_: ForcedWin side p) : Side := side
+def get_side {p : _root_.Position} {side : Side} (_: ForcedNotLose side p) : Side := side
 
 open ProofWidgets Penrose DiagramBuilderM Lean.Server
 
@@ -116,15 +116,15 @@ private unsafe def evalModuleUnsafe (e : Expr) : MetaM Module :=
 opaque evalModule (e : Expr) : MetaM Module
 
 
-/-- Extracts the position from a goal of type `ForcedWin`. -/
-def extractPositionFromForcedWinGoal (g : MVarId) : MetaM (Option _root_.Position) := do
+/-- Extracts the position from a goal of type `ForcedNotLose`. -/
+def extractPositionFromForcedNotLoseGoal (g : MVarId) : MetaM (Option _root_.Position) := do
   g.withContext do
     -- Get the goal's type
     let type ← g.getType
     -- Extract the function name and arguments using `getAppFnArgs`
     let (fn, args) := type.getAppFnArgs
-    -- Check if the goal is of type `ForcedWin`
-    if fn == ``ForcedWin && args.size == 2 then
+    -- Check if the goal is of type `ForcedNotLose`
+    if fn == ``ForcedNotLose && args.size == 2 then
       -- Extract the `Position` argument
       let posExpr := args[1]!  -- The second argument should be the Position
       -- Try to interpret `posExpr` as a `Position`
@@ -134,7 +134,7 @@ def extractPositionFromForcedWinGoal (g : MVarId) : MetaM (Option _root_.Positio
       return none
 
 open scoped Jsx in
-/-- The RPC method for displaying FEN for ForcedWin (Side → Position → Prop). -/
+/-- The RPC method for displaying FEN for ForcedNotLose (Side → Position → Prop). -/
 @[server_rpc_method]
 def forced_win_rpc (props : PanelWidgetProps) : RequestM (RequestTask Html) :=
   RequestM.asTask do
@@ -144,8 +144,8 @@ def forced_win_rpc (props : PanelWidgetProps) : RequestM (RequestTask Html) :=
       else
         let some g := props.goals[0]? | unreachable!
         g.ctx.val.runMetaM {} do
-          -- Use the extractPositionFromForcedWinGoal function
-          let posOpt ← extractPositionFromForcedWinGoal g.mvarId
+          -- Use the extractPositionFromForcedNotLoseGoal function
+          let posOpt ← extractPositionFromForcedNotLoseGoal g.mvarId
           match posOpt with
           | some posVal =>
             -- Create props for the ChessPositionWidget
@@ -157,13 +157,13 @@ def forced_win_rpc (props : PanelWidgetProps) : RequestM (RequestTask Html) :=
             return some <| combined_html
           | none => return none)
     match html with
-    | none => return <span>No ForcedWin goal found or invalid type.</span>
+    | none => return <span>No ForcedNotLose goal found or invalid type.</span>
     | some inner => return inner
 
 
 end Chess
 
 @[widget_module]
-def ForcedWinWidget :  Component PanelWidgetProps  :=
+def ForcedNotLoseWidget :  Component PanelWidgetProps  :=
     mk_rpc_widget% Chess.forced_win_rpc
 syntax (name := forcedWinWidget) "#forced_win_widget " term : command

--- a/FEN.py
+++ b/FEN.py
@@ -1,0 +1,44 @@
+UNICODE_PIECE = {
+    'r': '♜', 'n': '♞', 'b': '♝', 'q': '♛', 'k': '♚', 'p': '♟',
+    'R': '♖', 'N': '♘', 'B': '♗', 'Q': '♕', 'K': '♔', 'P': '♙',
+}
+
+def square_color(rank, file):
+    # rank, file are 0-based; rank 0 = 8th rank
+    return "░░" if (rank + file) % 2 == 0 else "▓▓"
+
+def render_fen(fen: str) -> str:
+    board_part, turn, *_ = fen.split()
+    ranks = board_part.split("/")
+
+    lines = []
+    lines.append("      ╔════════════════╗")
+
+    for r, rank_str in enumerate(ranks):
+        row = ""
+        file = 0
+        for ch in rank_str:
+            if ch.isdigit():
+                for _ in range(int(ch)):
+                    row += square_color(r, file)
+                    file += 1
+            else:
+                piece = UNICODE_PIECE[ch]
+                if ch.lower() == 'k' and ((turn == 'w' and ch.isupper()) or
+                                          (turn == 'b' and ch.islower())):
+                    row += piece + "}"
+                else:
+                    row += piece + "]"
+                file += 1
+
+        assert file == 8, "Rank does not have 8 squares"
+        lines.append(f"      ║{row}║")
+
+    lines.append("      ╚════════════════╝")
+    return "\n".join(lines)
+
+fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+print(render_fen(fen))
+
+fen = "Bq1B1K2/3PpN2/P3Pp2/P1p2P2/2Pk1b1R/1p6/pN1P1P2/QR6 w KQkq - 0 1"
+print(render_fen(fen))


### PR DESCRIPTION
Make it so that stalemates don't count as wins.

I retained the old code under names like ForcedNotLose, guess_next_moveNotLose, moveNotLose and so on.
To prove that at least one move is possible the tactic suggested by Lean seeems to always be:
      exact ne_of_beq_false rfl
So if you don't want to write that you can use ForcedNotLose.
Feel free to reject if you don't want these "NotLose" declarations.
